### PR TITLE
feat: add dynamic texte for bonus and game balancing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,54 @@
 ## Changelog
 
+# 2.5.1 - Théorisation & Transparence
+
+Cette mise à jour corrige les incohérences textuelles du Beer Clicker et rééquilibre l'unité emblématique "Clone de Théo".
+
+### Transparence Totale (Dynamic Descriptions)
+
+- **Vrais Chiffres** : Les descriptions du Shop ne mentent plus ! Elles affichent désormais la production **réelle** que vous gagnerez, en prenant en compte tous vos multiplicateurs actuels.
+  - _Exemple_ : Si vous avez un bonus global x2, le "Brasseur IA" affichera "10 000 bières/sec" au lieu de 5 000.
+- **Correction des Valeurs** : Certaines unités affichaient des valeurs incorrectes (ex: IA affichait 1k, donnait 5k). Le texte est maintenant directement lié au code du jeu pour une précision absolue.
+
+### Rééquilibrage "Clone de Théo"
+
+Le début de partie a été assoupli pour rendre la stratégie "Théo" viable :
+
+- **Clone de Théo** : Production doublée (0.5 -> **1 bière/sec**).
+- **Paquet de Clopes** :
+  - Coût drastiquement réduit (**6 000 -> 750**).
+  - Effet boosté (**+10% -> +25%**).
+- **Soirée Clones** :
+  - Coût réduit (**25 000 -> 10 000**).
+  - **Correctif d'Exploit** : Limité désormais à **1 achat maximum** pour empêcher la boucle infinie de rentabilité.
+
+### Auto-Clicker 2.0
+
+Le mode "Idle" était trop lent. Il a été accéléré :
+
+- **Vitesse de Base** : Triplée (1 clic/3s -> **1 clic/1s**).
+- **Potentiel Maximum** : Avec les améliorations, l'Auto-Clicker peut désormais atteindre une vitesse de croisière de ~5 clics/sec (contre ~1 clic/sec auparavant).
+
+### Réformes Structurelles (Usines & Clics)
+
+Des aberrations économiques ont été corrigées :
+
+- **Brasseries (Factories)** : La production de base a été augmentée (25 -> **60** bières/sec) pour qu'elles ne soient plus mathématiquement inférieures aux Startups.
+- **Logique des Clics** :
+  - **Levure Magique** : Devenue un objet de milieu de partie abordable. Coût divisé par 10 (50k -> **5k**), Effet renforcé (+3 -> **+5**).
+  - **Verre en Or** : Repositionné comme un objet de prestige de fin de jeu. Coût x50 (10k -> **500k**), Effet x5 (+10 -> **+50**).
+
+### Synergies & Fin de Partie
+
+- **Synergie Tech** : Coût réduit (75k -> **15k**) et Effet quintuplé (+1% -> **+5%** par Usine). Ce n'est plus un piège financier mais une vraie stratégie !
+- **Expansion Mondiale** : Repoussée pour lisser la courbe de progression (250k -> **500k**), mais rendue plus puissante (**+25%** production globale).
+
+### Amélioration Continue
+
+- **Multiplicateur (+1 Clic)** : La courbe de prix était trop punitive. Le facteur d'augmentation du coût a été adouci (x1.4 -> **x1.2**) pour que l'amélioration reste utile plus longtemps.
+
+---
+
 # 2.5.0 - Immersion Vacancière
 
 Cette mise à jour enrichit l'expérience visuelle du module Vacances avec des thèmes dynamiques et une refonte des horloges mondiales, tout en ajoutant des petites touches esthétiques aux modules.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "horaire",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/components/InfoColumn.vue
+++ b/src/components/InfoColumn.vue
@@ -171,7 +171,7 @@ onUnmounted(() => {
             :class="[sectionsSwapped ? 'order-3' : 'order-1', { 'flash-pause': isModuleEnding }, getCardClass(currentCourse)]">
             <!-- Fake Coding Animation Watermark -->
             <div
-                class="absolute top-0 bottom-0 right-2 w-32 opacity-20 pointer-events-none select-none overflow-hidden font-mono text-[10px] text-left text-blue-300 leading-tight mix-blend-overlay group-hover/current:scale-110 transition-transform origin-center fade-mask flex flex-col justify-center">
+                class="absolute top-0 bottom-0 right-2 w-32 opacity-80 pointer-events-none select-none overflow-hidden font-mono text-[10px] text-left text-blue-300 leading-tight mix-blend-overlay group-hover/current:scale-110 transition-transform origin-center fade-mask flex flex-col justify-center">
                 <div class="animate-code-scroll">
                     <!-- Block 1 -->
                     <div class="pb-4">

--- a/src/logic/gameData.js
+++ b/src/logic/gameData.js
@@ -314,6 +314,15 @@ export const getAchievements = (store) => [
   },
 ]
 
+export const GAME_CONSTANTS = {
+  BEER_DRINKER: { BASE_PROD: 1 },
+  FACTORY: { BASE_PROD: 60 },
+  STARTUP: { BASE_PROD: 5 },
+  PIPELINE: { BASE_PROD: 500 },
+  AI_BREWER: { BASE_PROD: 5000 },
+  QUANTUM: { BASE_PROD: 250000 },
+}
+
 export const getShopUpgrades = (store) => [
   {
     id: 'multiplierUpgrade',
@@ -322,7 +331,7 @@ export const getShopUpgrades = (store) => [
     description: 'Augmente le multiplicateur de clic de 1 de façon permanente.',
     image: multiplierImg,
     baseCost: 15,
-    costMultiplier: 1.4,
+    costMultiplier: 1.2,
     effect: function () {
       store.beerMultiplier += 1
     },
@@ -458,7 +467,13 @@ export const getShopUpgrades = (store) => [
     name: 'Brasserie',
     category: 'auto',
     image: factoryImg,
-    description: 'Investissez dans une brasserie pour produire 25 bières toutes les secondes.',
+    get description() {
+      const actualProd =
+        GAME_CONSTANTS.FACTORY.BASE_PROD *
+        store.brasserieBoosterMultiplier *
+        (store.globalMultiplier || 1)
+      return `Investissez dans une brasserie pour produire ${actualProd.toLocaleString()} bières toutes les secondes.`
+    },
     baseCost: 1200,
     costMultiplier: 1.2,
     effect: function () {
@@ -491,7 +506,13 @@ export const getShopUpgrades = (store) => [
     name: 'Louer un Théo',
     category: 'auto',
     image: theoImg,
-    description: 'Louez un clone de Théo pour générer 0.5 bière supplémentaire par seconde.',
+    get description() {
+      const actualProd =
+        GAME_CONSTANTS.BEER_DRINKER.BASE_PROD *
+        store.beerDrinkerBoosterMultiplier *
+        (store.globalMultiplier || 1)
+      return `Louez un clone de Théo pour générer ${actualProd.toLocaleString()} bière(s) supplémentaire(s) par seconde.`
+    },
     baseCost: 15,
     costMultiplier: 1.15,
     effect: function () {
@@ -534,7 +555,19 @@ export const getShopUpgrades = (store) => [
     name: 'Startup Étudiante',
     category: 'auto',
     image: startupImg,
-    description: 'Une équipe de stagiaires motivés. Produit 4 bières par seconde.',
+    get description() {
+      // Tech Synergy check
+      let synergyFactor = 1
+      if (store.upgrades['techSynergyUpgrade'] > 0 && store.upgrades['beerFactoryUpgrade'] > 0) {
+        synergyFactor = 1 + store.upgrades['beerFactoryUpgrade'] * 0.05
+      }
+      const actualProd =
+        GAME_CONSTANTS.STARTUP.BASE_PROD *
+        store.startupBoosterMultiplier *
+        (store.globalMultiplier || 1) *
+        synergyFactor
+      return `Une équipe de stagiaires motivés. Produit ${actualProd.toLocaleString()} bières par seconde.`
+    },
     baseCost: 100,
     costMultiplier: 1.4,
     effect: function () {
@@ -546,7 +579,13 @@ export const getShopUpgrades = (store) => [
     name: 'Oléoduc de Bière',
     category: 'auto',
     image: pipelineImg,
-    description: 'Un transport industriel ! Produit 150 bières par seconde.',
+    get description() {
+      const actualProd =
+        GAME_CONSTANTS.PIPELINE.BASE_PROD *
+        store.pipelineBoosterMultiplier *
+        (store.globalMultiplier || 1)
+      return `Un transport industriel ! Produit ${actualProd.toLocaleString()} bières par seconde.`
+    },
     baseCost: 15000,
     costMultiplier: 1.5,
     effect: function () {
@@ -558,11 +597,11 @@ export const getShopUpgrades = (store) => [
     name: 'Levure Magique',
     category: 'click',
     image: yeastImg,
-    description: 'Ajoute +3 à votre multiplicateur de clic.',
-    baseCost: 50000,
+    description: 'Ajoute +5 à votre multiplicateur de clic.',
+    baseCost: 5000,
     costMultiplier: 1.5,
     effect: function () {
-      store.beerMultiplier += 3
+      store.beerMultiplier += 5
     },
   },
   {
@@ -570,11 +609,11 @@ export const getShopUpgrades = (store) => [
     name: 'Paquet de clopes',
     category: 'bonus',
     image: cigarettesImg,
-    description: 'Augmente la production de vos clones de Théo de 10% par achat.',
-    baseCost: 6000,
+    description: 'Augmente la production de vos clones de Théo de 25% par achat.',
+    baseCost: 750,
     costMultiplier: 1.2,
     effect: function () {
-      store.beerDrinkerBoosterMultiplier *= 1.1
+      store.beerDrinkerBoosterMultiplier *= 1.25
     },
   },
   {
@@ -606,11 +645,11 @@ export const getShopUpgrades = (store) => [
     name: 'Verre en Or',
     category: 'click',
     image: goldGlassImg,
-    description: 'La classe ultime. (+10 Multiplicateur de clic)',
-    baseCost: 10000,
+    description: 'La classe ultime. (+50 Multiplicateur de clic)',
+    baseCost: 500000,
     costMultiplier: 1.5,
     effect: function () {
-      store.beerMultiplier += 10
+      store.beerMultiplier += 50
     },
   },
   {
@@ -619,8 +658,9 @@ export const getShopUpgrades = (store) => [
     category: 'bonus',
     image: clonePartyImg,
     description: "C'est la fête ! Vos clones de Théo produisent 2x plus.",
-    baseCost: 25000,
+    baseCost: 10000,
     costMultiplier: 1.5,
+    maxPurchases: 1,
     effect: function () {
       store.beerDrinkerBoosterMultiplier *= 2
     },
@@ -630,8 +670,8 @@ export const getShopUpgrades = (store) => [
     name: 'Synergie Tech',
     category: 'bonus',
     image: techSynergyImg,
-    description: '+1% production par Startup pour chaque Brasserie possédée.',
-    baseCost: 75000,
+    description: '+5% production par Startup pour chaque Brasserie possédée.',
+    baseCost: 15000,
     costMultiplier: 2,
     effect: function () {
       store.techSynergyActive = true
@@ -642,11 +682,11 @@ export const getShopUpgrades = (store) => [
     name: 'Expansion Mondiale',
     category: 'bonus',
     image: globalExpansionImg,
-    description: 'Exportez votre bière ! Production globale +20%.',
-    baseCost: 250000,
+    description: 'Exportez votre bière ! Production globale +25%.',
+    baseCost: 500000,
     costMultiplier: 1.5,
     effect: function () {
-      store.globalMultiplier *= 1.2
+      store.globalMultiplier *= 1.25
     },
   },
   {
@@ -654,7 +694,10 @@ export const getShopUpgrades = (store) => [
     name: 'Brasseur IA',
     category: 'auto',
     image: aiImg,
-    description: "L'intelligence artificielle au service de la soif. (1,000 bières/sec)",
+    get description() {
+      const actualProd = GAME_CONSTANTS.AI_BREWER.BASE_PROD * (store.globalMultiplier || 1)
+      return `L'intelligence artificielle au service de la soif. (${actualProd.toLocaleString()} bières/sec)`
+    },
     baseCost: 250000,
     costMultiplier: 1.5,
     effect: function () {
@@ -666,8 +709,10 @@ export const getShopUpgrades = (store) => [
     name: 'Brasserie Quantique',
     category: 'auto',
     image: quantumImg,
-    description:
-      'Produit de la bière dans toutes les dimensions simultanément. (25,000 bières/sec)',
+    get description() {
+      const actualProd = GAME_CONSTANTS.QUANTUM.BASE_PROD * (store.globalMultiplier || 1)
+      return `Produit de la bière dans toutes les dimensions simultanément. (${actualProd.toLocaleString()} bières/sec)`
+    },
     baseCost: 10000000,
     costMultiplier: 1.6,
     effect: function () {


### PR DESCRIPTION
# 2.5.1 - Théorisation & Transparence

Cette mise à jour corrige les incohérences textuelles du Beer Clicker et rééquilibre l'unité emblématique "Clone de Théo".

### Transparence Totale (Dynamic Descriptions)

- **Vrais Chiffres** : Les descriptions du Shop ne mentent plus ! Elles affichent désormais la production **réelle** que vous gagnerez, en prenant en compte tous vos multiplicateurs actuels.
  - _Exemple_ : Si vous avez un bonus global x2, le "Brasseur IA" affichera "10 000 bières/sec" au lieu de 5 000.
- **Correction des Valeurs** : Certaines unités affichaient des valeurs incorrectes (ex: IA affichait 1k, donnait 5k). Le texte est maintenant directement lié au code du jeu pour une précision absolue.

### Rééquilibrage "Clone de Théo"

Le début de partie a été assoupli pour rendre la stratégie "Théo" viable :

- **Clone de Théo** : Production doublée (0.5 -> **1 bière/sec**).
- **Paquet de Clopes** :
  - Coût drastiquement réduit (**6 000 -> 750**).
  - Effet boosté (**+10% -> +25%**).
- **Soirée Clones** :
  - Coût réduit (**25 000 -> 10 000**).
  - **Correctif d'Exploit** : Limité désormais à **1 achat maximum** pour empêcher la boucle infinie de rentabilité.

### Auto-Clicker 2.0

Le mode "Idle" était trop lent. Il a été accéléré :

- **Vitesse de Base** : Triplée (1 clic/3s -> **1 clic/1s**).
- **Potentiel Maximum** : Avec les améliorations, l'Auto-Clicker peut désormais atteindre une vitesse de croisière de ~5 clics/sec (contre ~1 clic/sec auparavant).

### Réformes Structurelles (Usines & Clics)

Des aberrations économiques ont été corrigées :

- **Brasseries (Factories)** : La production de base a été augmentée (25 -> **60** bières/sec) pour qu'elles ne soient plus mathématiquement inférieures aux Startups.
- **Logique des Clics** :
  - **Levure Magique** : Devenue un objet de milieu de partie abordable. Coût divisé par 10 (50k -> **5k**), Effet renforcé (+3 -> **+5**).
  - **Verre en Or** : Repositionné comme un objet de prestige de fin de jeu. Coût x50 (10k -> **500k**), Effet x5 (+10 -> **+50**).

### Synergies & Fin de Partie

- **Synergie Tech** : Coût réduit (75k -> **15k**) et Effet quintuplé (+1% -> **+5%** par Usine). Ce n'est plus un piège financier mais une vraie stratégie !
- **Expansion Mondiale** : Repoussée pour lisser la courbe de progression (250k -> **500k**), mais rendue plus puissante (**+25%** production globale).

### Amélioration Continue

- **Multiplicateur (+1 Clic)** : La courbe de prix était trop punitive. Le facteur d'augmentation du coût a été adouci (x1.4 -> **x1.2**) pour que l'amélioration reste utile plus longtemps.